### PR TITLE
Add open using File, on systems with FS.h

### DIFF
--- a/src/JPEGDEC.cpp
+++ b/src/JPEGDEC.cpp
@@ -142,6 +142,35 @@ int JPEGDEC::open(const char *szFilename, JPEG_OPEN_CALLBACK *pfnOpen, JPEG_CLOS
 
 } /* open() */
 
+#ifdef FS_H
+static int32_t FileRead(JPEGFILE *handle, uint8_t *buffer, int32_t length)
+{
+    return ((File *)(handle->fHandle))->read(buffer, length);
+}
+static int32_t FileSeek(JPEGFILE *handle, int32_t position)
+{
+    return ((File *)(handle->fHandle))->seek(position);
+}
+static void FileClose(void *handle)
+{
+    ((File *)handle)->close();
+}
+
+int JPEGDEC::open(File &file, JPEG_DRAW_CALLBACK *pfnDraw)
+{
+    if (!file) return 0;
+    memset(&_jpeg, 0, sizeof(JPEGIMAGE));
+    _jpeg.pfnRead = FileRead;
+    _jpeg.pfnSeek = FileSeek;
+    _jpeg.pfnClose = FileClose;
+    _jpeg.pfnDraw = pfnDraw;
+    _jpeg.iMaxMCUs = 1000;
+    _jpeg.JPEGFile.fHandle = &file;
+    _jpeg.JPEGFile.iSize = file.size();
+    return JPEGInit(&_jpeg);
+}
+#endif // FS_H
+
 void JPEGDEC::close()
 {
     if (_jpeg.pfnClose)

--- a/src/JPEGDEC.h
+++ b/src/JPEGDEC.h
@@ -22,6 +22,9 @@
 #define PROGMEM
 #else
 #include <Arduino.h>
+#if defined(__has_include) && __has_include(<FS.h>)
+#include "FS.h"
+#endif
 #endif
 //
 // JPEG Decoder
@@ -200,6 +203,9 @@ class JPEGDEC
     int openRAM(uint8_t *pData, int iDataSize, JPEG_DRAW_CALLBACK *pfnDraw);
     int openFLASH(uint8_t *pData, int iDataSize, JPEG_DRAW_CALLBACK *pfnDraw);
     int open(const char *szFilename, JPEG_OPEN_CALLBACK *pfnOpen, JPEG_CLOSE_CALLBACK *pfnClose, JPEG_READ_CALLBACK *pfnRead, JPEG_SEEK_CALLBACK *pfnSeek, JPEG_DRAW_CALLBACK *pfnDraw);
+#ifdef FS_H
+    int open(File &file, JPEG_DRAW_CALLBACK *pfnDraw);
+#endif
     void close();
     int decode(int x, int y, int iOptions);
     int decodeDither(uint8_t *pDither, int iOptions);


### PR DESCRIPTION
This adds a 3rd open function which can take a File object.

It only works on systems which provide the FS.h filesystem abstraction.  Currently ESP8266 and ESP32 have this, and I'm adding it for Teensy.  Preprocessor checking is done to not compile any of this stuff when the FS.h header doesn't exist.