### PR TITLE
Add ESP-IDF CMakeLists.txt so it can be used as "a component" using git submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(srcs 
+    "src/JPEGDEC.cpp"
+    "src/jpeg.inl"
+)
+idf_component_register(SRCS ${srcs}      
+                    REQUIRES "jpegdec"
+                    INCLUDE_DIRS "src"
+)


### PR DESCRIPTION
This small CMakeLists contribution is to enable this to be used as an ESP-IDF component directly. 

So after this we can simply do a: 

**git submodule add https://github.com/bitbank2/JPEGDEC.git components/jpegdec**

And then on the build:   idf.py build

esp-idf will simply have it ready to be used "as a component" that can be included to your Firmware.