### PR TITLE
Include esp32-idf only in the non-Arduino set

### DIFF
--- a/src/JPEGDEC.h
+++ b/src/JPEGDEC.h
@@ -13,7 +13,7 @@
 //
 #ifndef __JPEGDEC__
 #define __JPEGDEC__
-#if defined( __MACH__ ) || defined( __LINUX__ ) || defined( __MCUXPRESSO )
+#if defined( __MACH__ ) || defined( __LINUX__ ) || defined( __MCUXPRESSO ) || defined( ESP_PLATFORM )
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>


### PR DESCRIPTION
I tested this with IDF 4.4.0 on the ESP32.   In theory it is supposed to apply to anything built with the IDF makefiles. 