### PR TITLE
Remove compiler warnings when building for Arduino (Teensy 4.1)

### DIFF
--- a/src/jpeg.inl
+++ b/src/jpeg.inl
@@ -33,9 +33,11 @@ static void JPEGGetMoreData(JPEGIMAGE *pPage);
 static int DecodeJPEG(JPEGIMAGE *pImage);
 static int32_t readRAM(JPEGFILE *pFile, uint8_t *pBuf, int32_t iLen);
 static int32_t seekMem(JPEGFILE *pFile, int32_t iPosition);
+#if defined (__MACH__) || defined( __LINUX__ ) || defined( __MCUXPRESSO )
 static int32_t readFile(JPEGFILE *pFile, uint8_t *pBuf, int32_t iLen);
 static int32_t seekFile(JPEGFILE *pFile, int32_t iPosition);
 static void closeFile(void *handle);
+#endif
 static void JPEGDither(JPEGIMAGE *pJPEG, int iWidth, int iHeight);
 /* JPEG tables */
 // zigzag ordering of DCT coefficients


### PR DESCRIPTION
There were three warning messages about static methods defined, but not implemented.

I put same #if around the defines as there were around the implementations.

Note: Only test built using Teensy 4.1 and 3.6