### PR TITLE
fix: add esp-dsp dep and add assembly files to sources list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 set(srcs 
     "src/JPEGDEC.cpp"
     "src/jpeg.inl"
+    "src/s3_simd_420.S"
+    "src/s3_simd_444.S"
+    "src/s3_simd_dequant.S"
 )
 idf_component_register(SRCS ${srcs}      
-                    REQUIRES "jpegdec"
+                    REQUIRES "jpegdec" "esp-dsp"
                     INCLUDE_DIRS "src"
 )


### PR DESCRIPTION
Hey! Thanks for the repo! I've tried to use the latest version of your component as an esp-idf component within [esp-box-emu](https://github.com/esp-cpp/esp-box-emu) and in order to do so I had to make these changes, but overall I was able to get ~20% speedup on average in decoding my jpeg boxarts, so thanks a lot!