### PR TITLE
Fix progressive grayscale decode with separate component scans

### DIFF
--- a/src/jpeg.inl
+++ b/src/jpeg.inl
@@ -5225,8 +5225,15 @@ static int DecodeJPEG(JPEGIMAGE *pJPEG)
                 if (pJPEG->ucPixelType >= EIGHT_BIT_GRAYSCALE) {
                     // We're not going to use the color channels, so avoid as much work as possible
                     if (pJPEG->ucMode == 0xc2) { // progressive
-                        iErr |= JPEGDecodeMCU_P(pJPEG, MCU_SKIP, &iDCPred1);
-                        iErr |= JPEGDecodeMCU_P(pJPEG, MCU_SKIP, &iDCPred2);
+                        // A progressive scan can contain luma without either chroma component.
+                        // Only consume entropy data for components present in this scan.
+                        if (pJPEG->JPCI[1].component_needed)
+                            iErr |= JPEGDecodeMCU_P(pJPEG, MCU_SKIP, &iDCPred1);
+                        if (pJPEG->JPCI[2].component_needed) {
+                            pJPEG->ucACTable = cACTable2;
+                            pJPEG->ucDCTable = cDCTable2;
+                            iErr |= JPEGDecodeMCU_P(pJPEG, MCU_SKIP, &iDCPred2);
+                        }
                     } else {
                         iErr |= JPEGDecodeMCU(pJPEG, MCU_SKIP, &iDCPred1); // decode Cr block
                         iErr |= JPEGDecodeMCU(pJPEG, MCU_SKIP, &iDCPred2); // decode Cb block


### PR DESCRIPTION
## Summary

Progressive JPEGs may place the luminance DC coefficients in the first scan and defer both chroma components to a later scan. When decoding that first scan as `EIGHT_BIT_GRAYSCALE`, `DecodeJPEG()` currently calls `JPEGDecodeMCU_P(..., MCU_SKIP, ...)` for Cb and Cr even though neither component is present in the entropy stream.

Check each scan component's existing `component_needed` flag before consuming its entropy data. This avoids reading absent chroma data and lets the valid luminance-only scan produce the documented 1/8-scale progressive preview.

This adds no allocation and leaves baseline, single-component progressive, and color-output paths unchanged.

## Reproduction

The failure can be reproduced without third-party image content by creating a 4:4:4 progressive JPEG with this libjpeg scan script:

```text
0:   0-0,  0, 0;
1,2: 0-0,  0, 0;
0:   1-63, 0, 0;
1:   1-63, 0, 0;
2:   1-63, 0, 0;
```

Decode it using:

```cpp
jpeg.setPixelType(EIGHT_BIT_GRAYSCALE);
jpeg.decode(0, 0, JPEG_SCALE_EIGHTH);
```

At current `master` (`8628297`), the decoder attempts the absent chroma blocks and crashes under the host harness. With this patch it returns success and invokes the draw callback for all eight output rows.

## Validation

- Synthetic 96x64 Y-only first progressive scan: baseline crashes; fixed decoder returns `decode=1 error=0 draw_calls=8`.
- Real-world 600x900 Y-only first progressive scan: baseline crashes; fixed decoder returns `decode=1 error=0 draw_calls=113`.
- Baseline color JPEG control: both return `decode=1 error=0 draw_calls=8`.
- Single-component progressive grayscale control: both return `decode=1 error=0 draw_calls=8`.
- Native-decoder CrossPoint emulator: baseline image is blank; fixed image renders and survives a cold cache reopen.

## Emulator evidence

These screenshots are emulator-only evidence, not physical-device validation.

| Baseline: valid cover decodes as blank | Fixed: cover renders |
| --- | --- |
| ![Baseline emulator screenshot: blank cover](https://raw.githubusercontent.com/lpla/crosspoint-reader/4b9eeac1183021961466e9893e69459dc9703af5/evidence/baseline.png) | ![Fixed emulator screenshot: rendered cover](https://raw.githubusercontent.com/lpla/crosspoint-reader/4b9eeac1183021961466e9893e69459dc9703af5/evidence/fixed.png) |

Related, but distinct because it concerns components that are present in the scan: #119.
